### PR TITLE
[Add]プロフィール画像を丸く表示

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -69,6 +69,7 @@
   img {
    width: 30px;
    height: 30px;
+   border-radius: 100px;
   }
  }
 
@@ -115,9 +116,9 @@
 }
 
 .you .icon img {
-  width: 100%;
-  height: auto;
-  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  border-radius: 100%;
 }
 
 .you .chat {

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -19,7 +19,7 @@ class Member < ApplicationRecord
   has_one_attached :profile_image
 
   def get_profile_image
-    (profile_image.attached?) ? profile_image : 'no-image.PNG'
+    (profile_image.attached?) ? profile_image : "no-image.PNG"
   end
 
   def follow(member)

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -17,11 +17,6 @@
               <% end %>
             </li>
             <li class="nav-item">
-              <%= link_to rooms_path, class: 'nav-link text-dark' do %>
-                <%= image_tag 'Dogs-logo2.PNG', style: "width: 20px;" %>チャット
-              <% end %>
-            </li>
-            <li class="nav-item">
               <%= link_to new_post_path, class: 'nav-link text-dark' do %>
                 <%= image_tag 'Dogs-logo2.PNG', style: "width: 20px;" %>投稿する
               <% end %>
@@ -31,11 +26,17 @@
                 <%= image_tag 'Dogs-logo2.PNG', style: "width: 20px;" %>みんなの投稿
               <% end %>
             </li>
-            <% if unchecked_notifications.any? %>
-              <i class="fa fa-circle" style="color: gold;"></i>
-            <% end %>
+            <li class="nav-item">
+              <%= link_to rooms_path, class: 'nav-link text-dark' do %>
+                <%= image_tag 'Dogs-logo2.PNG', style: "width: 20px;" %>チャット
+              <% end %>
+            </li>
+
             <li class="nav-item">
               <%= link_to notifications_path, class: 'nav-link text-dark' do %>
+                <% if unchecked_notifications.any? %>
+                  <i class="fa fa-circle" style="color: red; width: 10px; vertical-align: top;"></i>
+                <% end %>
                 <%= image_tag 'Dogs-logo2.PNG', style: "width: 20px;" %>通知
               <% end %>
             </li>
@@ -54,11 +55,6 @@
             <li class="nav-item">
               <%= link_to homes_about_path, class: 'nav-link text-dark' do %>
                 <%= image_tag 'Dogs-logo2.PNG', style: "width: 20px;" %>Dogsって？
-              <% end %>
-            </li>
-            <li class="nav-item">
-              <%= link_to posts_path, class: 'nav-link text-dark' do %>
-                <%= image_tag 'Dogs-logo2.PNG', style: "width: 20px;" %>投稿一覧
               <% end %>
             </li>
             <li class="nav-item">

--- a/app/views/public/members/show.html.erb
+++ b/app/views/public/members/show.html.erb
@@ -3,7 +3,7 @@
     <div class="col-4">
       <table class="table">
         <h2 style="text-align: center;"><%= @member.name %>のプロフィール</h2>
-        <tr><%= image_tag @member.get_profile_image, size: "100x100" %></tr>
+        <tr><%= image_tag @member.get_profile_image, class: "rounded-circle", size: "100x100" %></tr>
         <tr style="text-align: center;">
           <th>投稿<br><%= @member.posts.count %></th>
           <th>

--- a/app/views/public/members/withdraw.html.erb
+++ b/app/views/public/members/withdraw.html.erb
@@ -1,2 +1,0 @@
-<h1>Public::Members#withdraw</h1>
-<p>Find me in app/views/public/members/withdraw.html.erb</p>

--- a/app/views/public/notifications/_notification.html.erb
+++ b/app/views/public/notifications/_notification.html.erb
@@ -3,7 +3,7 @@
 
 <div>
   <%= link_to member_path(visitor) do %>
-    <%= image_tag visitor.get_profile_image, size: "50x50", class: "profile-img-circle" %>
+    <%= image_tag visitor.get_profile_image, size: "50x50", class: "rounded-circle" %>
   <% end %>
   <%= notification_form(notification) %>
   <br>

--- a/app/views/public/notifications/index.html.erb
+++ b/app/views/public/notifications/index.html.erb
@@ -2,17 +2,18 @@
   <div class="row">
     <div class="mx-auto col-10">
       <h2>通知</h2>
+      <hr>
+      <%= link_to destroy_all_path, method: :delete do %>
+        <i class="fas fa-trash" style="color: black;"></i>
+        <span style="color: black;">全削除</span>
+      <% end %>
+      <br><br>
       <% if @notifications.exists? %>
         <div>
           <%= render @notifications %>
         </div>
       <% else %>
           <p>通知はありません</p>
-      <% end %>
-      <hr>
-      <%= link_to destroy_all_path, method: :delete do %>
-        <i class="fas fa-trash" style="color: black;"></i>
-        <span style="color: black;">全削除</span>
       <% end %>
     </div>
   </div>

--- a/app/views/public/posts/_index.html.erb
+++ b/app/views/public/posts/_index.html.erb
@@ -2,9 +2,9 @@
   <% posts.each do |post| %>
     <div class="col-md-4">
       <div class="card mb-4 shadow-sm">
-        <div class="card-header">
+        <div class="card-header profile_image">
           <%= link_to member_path(post.member.id) do %>
-            <%= image_tag post.member.get_profile_image, size: "30x30" %>
+            <%= image_tag post.member.get_profile_image %>
           <% end %>
         </div>
         <% if post.post_image.present? %>


### PR DESCRIPTION
## プロフィール画像を丸く表示されるように調整しました。
- プロフィール画像を丸く表示されるように調整
- 不要なファイルの削除
- ログイン前のヘッダーから投稿一覧ボタンを削除